### PR TITLE
Feature/fix bin move across disks

### DIFF
--- a/update.go
+++ b/update.go
@@ -83,7 +83,7 @@ func (m *Manager) InstallTo(path, dir string) error {
 
 	log.Debugf("copy %q to %q", bin, dst)
 
-	if err := fileutils.CopyFile(bin, dst); err != nil {
+	if err := fileutils.CopyFile(dst, bin); err != nil {
 		return errors.Wrap(err, "copy")
 	}
 

--- a/update.go
+++ b/update.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/fileutils"
+
 	"github.com/apex/log"
 	"github.com/c4milo/unpackit"
 	"github.com/pkg/errors"
@@ -81,31 +83,11 @@ func (m *Manager) InstallTo(path, dir string) error {
 
 	log.Debugf("copy %q to %q", bin, dst)
 
-	if err := copy(bin, dst); err != nil {
+	if err := fileutils.CopyFile(bin, dst); err != nil {
 		return errors.Wrap(err, "copy")
 	}
 
 	return nil
-}
-
-func copy(src, dst string) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer in.Close()
-
-	out, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-
-	_, err = io.Copy(out, in)
-	if err != nil {
-		return err
-	}
-	return out.Close()
 }
 
 // Install binary to replace the current version.

--- a/update.go
+++ b/update.go
@@ -79,12 +79,33 @@ func (m *Manager) InstallTo(path, dir string) error {
 
 	dst := filepath.Join(dir, m.Command)
 
-	log.Debugf("move %q to %q", bin, dst)
-	if err := os.Rename(bin, dst); err != nil {
-		return errors.Wrap(err, "moving")
+	log.Debugf("copy %q to %q", bin, dst)
+
+	if err := copy(bin, dst); err != nil {
+		return errors.Wrap(err, "copy")
 	}
 
 	return nil
+}
+
+func copy(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, in)
+	if err != nil {
+		return err
+	}
+	return out.Close()
 }
 
 // Install binary to replace the current version.


### PR DESCRIPTION
Under Windows it's not possible to rename a file across different disks. We have to copy it.

**Log**
```
[232] 2018/01/18 22:59:31.073878 [FTL] error installing: moving: rename C:\Users\dustin\AppData\Local\Temp\unpackit-687533202\butler.exe E:\go\work\bin\butler.exe: The system cannot move the file to a different disk drive.
```
**Explanation**
> The file cannot be moved to a different disk drive at the same time you rename it using the Rename command.

Reference:
https://msdn.microsoft.com/en-us/library/ms837428.aspx