### PR TITLE
add windows compatibility workaround

### DIFF
--- a/update.go
+++ b/update.go
@@ -84,6 +84,14 @@ func (m *Manager) InstallTo(path, dir string) error {
 	if err := copyFile(tmp, bin); err != nil {
 		return errors.Wrap(err, "copying")
 	}
+	
+	if runtime.GOOS == "windows" {
+		old := dst + ".old"
+		log.Debugf("windows workaround renaming %q to %q", dst, old)
+		if err := os.Rename(dst, old); err != nil {
+			return errors.Wrap(err, "windows renaming")
+		}
+	}	
 
 	log.Debugf("renaming %q to %q", bin, dst)
 	if err := os.Rename(tmp, dst); err != nil {


### PR DESCRIPTION
In Windows we can't directly replace running binaries. It seems the previous fix attempt on this got lost. This code snippet makes the windows workaround explicit in code and moves the current binary to dst + ".old". I've tested this and use this in my fork on windows: https://github.com/diodechain/go-update